### PR TITLE
Changes to add flexibility to config (including extra placeholder params, and support for resource queries)

### DIFF
--- a/utils/emitFile.js
+++ b/utils/emitFile.js
@@ -6,10 +6,14 @@ const hashContent = (content, length) =>
   crypto.createHash("md5").update(content).digest("hex").slice(0, length);
 
 module.exports = function (content, filepath, emitFile = true) {
-  const { ext, name } = path.parse(this.context.resourcePath);
+  const { dir, ext, name } = path.parse(this.context.resourcePath);
 
   // Placeholder values to replace
   const replacements = [
+    {
+      test: /\[dir]/g,
+      replace: dir,
+    },
     {
       test: /\[name]/g,
       replace: name,


### PR DESCRIPTION
Adds `[dir]` as a placeholder value, to allow access to the original file path when outputting files.

I've found need for this when I want to maintain a directory structure in production. For example, with the following...

```
...
loaders: [
  {
    loader: require("eleventy-load-file"),
    options: {
      name: "[name].[hash].[ext]",
      publicPath: "[dir]",
    },
  },
],
...
```
...and this file structure...
```
/media
  /styles
    /core.scss
    /subsite
      /a.scss
      /b.scss
```
...I can easily maintain this output...
```
/media
  /styles
    /core.<hash>.css
    /subsite
      /a.<hash>.css
      /b.<hash>.css
```
Make of this what you will! Just something I've found useful.