### PR TITLE
Add config for CI tests and Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "10:00"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "10:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm test

--- a/.npmignore
+++ b/.npmignore
@@ -2,9 +2,12 @@
 .eslintcache
 /coverage
 
-# exlude development files
+# exclude development files
 .editorconfig
 .eslintrc
 jest.config.js
 *.test.js
 testUtils
+
+# exclude CI configs
+.github


### PR DESCRIPTION
This PR for issue #8 contains config to enable:

- Github action to run tests on every push to the repo
- Dependabot settings to raise PRs for any updated dependencies. With tests running on each push we can be confident that dependency updates pass tests before merging.

https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/