### PR TITLE
Update CI config for windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
         node: [10, 12, 14, 16]
+        os: [ubuntu-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        exclude:
-          - os: windows-latest
-            node: [10, 16]
+        include:
+          - node: 14
+            os: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,16 @@ on: [push]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        os: [ubuntu-latest, windows-latest]
+        node: [10, 12, 14, 16]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        exclude:
+          - os: windows-latest
+            node: [10, 16]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR add windows os to the CI tests as per #19 

- [x] Runs tests for node versions 10 though 16 (plugin might be used on old node versions)
- [x] Run once on windows with node@14