### PR TITLE
11ty version compatibility checking

### DIFF
--- a/EleventyLoad.js
+++ b/EleventyLoad.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
-const { emitFile, DEBUG_STRING } = require("./utils");
+const pkg = require("./package.json");
+const { emitFile } = require("./utils");
 
 module.exports = class EleventyLoad {
   constructor(options, cache, resource, content, config, cachePath) {
@@ -22,7 +23,7 @@ module.exports = class EleventyLoad {
 
   debug(string, override) {
     if (this.options.debug || override) {
-      console.info(`${DEBUG_STRING} ${string}`);
+      console.info(`[${pkg.name}] ${string}`);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,17 @@
 const path = require("path");
+const pkg = require("./package.json");
 const { createConfig, DEBUG_STRING } = require("./utils");
 const EleventyLoad = require("./EleventyLoad");
 
 module.exports = function (config, options) {
+  try {
+    config.versionCheck(pkg["11ty"].compatibility);
+  } catch (e) {
+    console.warn(
+      `WARN: Eleventy Plugin (${pkg.name}) Compatibility: ${e.message}`
+    );
+  }
+
   // Return and warn if no rules are given
   if (!(options.rules instanceof Array)) {
     console.warn(`${DEBUG_STRING} Try giving me some rules!`);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const pkg = require("./package.json");
-const { createConfig, DEBUG_STRING } = require("./utils");
+const { createConfig } = require("./utils");
 const EleventyLoad = require("./EleventyLoad");
 
 module.exports = function (config, options) {
@@ -14,7 +14,7 @@ module.exports = function (config, options) {
 
   // Return and warn if no rules are given
   if (!(options.rules instanceof Array)) {
-    console.warn(`${DEBUG_STRING} Try giving me some rules!`);
+    console.warn(`[${pkg.name}] Try giving me some rules!`);
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.0",
   "description": "Use loaders to post-process files in your Eleventy project",
   "main": "index.js",
+  "11ty": {
+    "compatibility": ">=0.5.0 <2.x"
+  },
   "scripts": {
     "release": "np",
     "lint": "eslint --ext .js --cache",

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,10 +1,7 @@
 const emitFile = require("./emitFile");
 const createConfig = require("./createConfig");
 
-const DEBUG_STRING = "[eleventy-load]";
-
 module.exports = {
   emitFile,
   createConfig,
-  DEBUG_STRING,
 };


### PR DESCRIPTION
This PR adds an 11ty version compatibility check. It allows our plugin to assert what versions of 11ty it is compatible with.

I've set it to fail with the next major release. This will give users a warning about what failed when they upgrade 11ty. On a new major version we will check compatibility, add tests, and increment the supported version.

I've set the minimum supported version very low - its basically a guess but we can change that if anyone reports an issue with a really old 11ty version.

Also refactored the `DEBUG_STRING` to use the package name.

@gregives change requests welcome, otherwise I'll merge in a few days.
